### PR TITLE
fix: :bug: fixed controller focus for main menu button

### DIFF
--- a/Pasha-Brotatogether/extensions/ui/menus/pages/main_menu.gd
+++ b/Pasha-Brotatogether/extensions/ui/menus/pages/main_menu.gd
@@ -1,20 +1,34 @@
 extends "res://ui/menus/pages/main_menu.gd"
 
+
+var multiplayer_button: Button
+
 # Add a multiplayer button to the main menu
 func _ready():
 	var buttons_node = $"HBoxContainer/ButtonsLeft"
-	
+
 	# Duplicate a Button to get the styling
-	var multiplayer_button = start_button.duplicate()
+	multiplayer_button = continue_button.duplicate()
 	multiplayer_button.text = "Multiplayer"
-	
+	multiplayer_button.name = "MultiplayerButton"
+
 	multiplayer_button.connect("pressed", self, "_on_MultiplayerButton_pressed")
 	multiplayer_button.disconnect("pressed", self, "_on_StartButton_pressed")
-	
+
 	buttons_node.add_child_below_node(buttons_node.get_children()[0], multiplayer_button)
 	buttons_node.move_child(multiplayer_button, 0)
-	
+
+
 	remove_game_controller()
+
+
+func init() -> void:
+	.init()
+	if continue_button.visible:
+		continue_button.focus_neighbour_top = multiplayer_button.get_path()
+	else:
+		start_button.focus_neighbour_top = multiplayer_button.get_path()
+
 
 func _on_MultiplayerButton_pressed():
 	var _error = get_tree().change_scene("res://mods-unpacked/Pasha-Brotatogether/ui/multiplayer_menu.tscn")

--- a/Pasha-Brotatogether/extensions/ui/menus/pages/main_menu.gd
+++ b/Pasha-Brotatogether/extensions/ui/menus/pages/main_menu.gd
@@ -8,7 +8,7 @@ func _ready():
 	var buttons_node = $"HBoxContainer/ButtonsLeft"
 
 	# Duplicate a Button to get the styling
-	multiplayer_button = continue_button.duplicate()
+	multiplayer_button = start_button.duplicate()
 	multiplayer_button.text = "Multiplayer"
 	multiplayer_button.name = "MultiplayerButton"
 


### PR DESCRIPTION
Added an override for the `init()` function in *main_menu.gd* to edit the `focus_neighbour_top` on the continue and start button.

It's still far from perfect, but at least the button is now reachable 😄 

Potential improvements:
- The "Quit" button is currently skipping the multiplayer button. Change it to just focus on the first button on the left side.
- The right/left focus behavior is incorrect.